### PR TITLE
fix: window not coming to focus when clicking content area

### DIFF
--- a/main.js
+++ b/main.js
@@ -375,6 +375,15 @@ ipcMain.handle('minimize-window', () => {
   }
 });
 
+ipcMain.handle('focus-window', () => {
+  if (mainWindow) {
+    if (!mainWindow.isFocused()) {
+      mainWindow.focus();
+      mainWindow.moveTop();
+    }
+  }
+});
+
 // Updates IPC
 ipcMain.handle('check-for-updates', async () => {
   if (!app.isPackaged) return { status: 'dev' };

--- a/renderer.js
+++ b/renderer.js
@@ -382,6 +382,17 @@ function wireUI() {
     hotkeySearch.addEventListener('input', hotkeys.renderHotkeysTab);
   }
 
+  // Add click handler to widget content to bring window to focus
+  const widgetContent = document.querySelector('.widget-content');
+  if (widgetContent) {
+    widgetContent.addEventListener('mousedown', () => {
+      // Request window focus when clicking on content
+      ipcRenderer.invoke('focus-window').catch(err => {
+        console.error('Failed to focus window:', err);
+      });
+    });
+  }
+
   const hotkeysList = document.getElementById('hotkeys-list');
   if (hotkeysList) {
     hotkeysList.addEventListener('click', async (e) => {


### PR DESCRIPTION
- Added mousedown event listener to widget-content area
- Added IPC handler 'focus-window' to bring window to front
- Window now properly focuses and moves to top when clicking anywhere in content
- Fixes issue where clicking content area didn't focus window but clicking header did