### PR TITLE
fix: Open Settings tray menu option now works

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -208,6 +208,20 @@ window.electronAPI.onHotkeyTriggered(({ entityId, action }) => {
   }
 });
 
+// Listen for open-settings event from tray menu
+window.electronAPI.onOpenSettings(() => {
+  settings.openSettings({
+    initUpdateUI: ui.initUpdateUI,
+    exitReorganizeMode: () => {
+      // Exit reorganize mode if active
+      const container = document.getElementById('quick-controls');
+      if (container && container.classList.contains('reorganize-mode')) {
+        ui.toggleReorganizeMode();
+      }
+    },
+  });
+});
+
 /**
  * Replace all emoji icons with SVG icons
  * This runs once on initialization to modernize the UI


### PR DESCRIPTION
## Summary
The 'Open Settings' context menu option in the system tray was not functioning.

## Root Cause
The renderer process was not listening for the \open-settings\ IPC event from the main process. While:
- \main.js\ correctly sends the event via \mainWindow.webContents.send('open-settings')\
- \preload.js\ correctly exposes \onOpenSettings\ via \window.electronAPI\

The \enderer.js\ never subscribed to this event.

## Fix
Added the missing \window.electronAPI.onOpenSettings()\ listener in \enderer.js\ that calls \settings.openSettings()\ when triggered from the tray menu, using the same logic as the settings button click handler.

## Testing
- Right-click tray icon → 'Open Settings' now correctly opens the settings modal