### PR TITLE
docs: add downloads badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A semi-transparent desktop widget for Home Assistant that provides quick access 
 [![CI](https://github.com/Robertg761/HA-Desktop-Widget/actions/workflows/ci.yml/badge.svg)](https://github.com/Robertg761/HA-Desktop-Widget/actions/workflows/ci.yml)
 [![Release](https://github.com/Robertg761/HA-Desktop-Widget/actions/workflows/release.yml/badge.svg)](https://github.com/Robertg761/HA-Desktop-Widget/actions/workflows/release.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-green.svg)](LICENSE)
+[![Downloads](https://img.shields.io/github/downloads/Robertg761/HA-Desktop-Widget/total?color=blue&label=downloads)](https://github.com/Robertg761/HA-Desktop-Widget/releases)
 
 - Download: https://github.com/Robertg761/HA-Desktop-Widget/releases
 


### PR DESCRIPTION
Adds a shields.io GitHub-release downloads badge to the top badge cluster in the README, linking to the releases page.

The badge reflects total downloads across all release assets (currently ~14k) and updates automatically.

```markdown
[![Downloads](https://img.shields.io/github/downloads/Robertg761/HA-Desktop-Widget/total?color=blue&label=downloads)](https://github.com/Robertg761/HA-Desktop-Widget/releases)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)