### PR TITLE
fix: keep modal dialogs readable when backdrop blur is unavailable

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -97,10 +97,11 @@ html {
   --glass-surface: rgba(30, 30, 35, 0.7);
   --glass-elevated: rgba(40, 40, 45, 0.8);
   --glass-overlay: rgba(20, 20, 25, 0.85);
-  /* Near-opaque layer painted beneath modal glass tints so dialog text stays
+  /* Base color of the layer painted beneath modal glass tints (see
+     .modal-content, where its alpha is computed) so dialog text stays
      readable even where backdrop-filter silently fails (e.g. transparent
      Electron windows on Linux/Windows). */
-  --modal-backstop: rgba(26, 26, 31, 0.92);
+  --modal-backstop-rgb: 26, 26, 31;
   --settings-modal-bg-rgb: 24, 24, 29;
   --settings-modal-bg-alpha: 0.82;
   --settings-modal-panel-rgb: 31, 31, 37;
@@ -250,7 +251,7 @@ html {
   --glass-surface: rgba(255, 255, 255, 0.7);
   --glass-elevated: rgba(250, 250, 250, 0.8);
   --glass-overlay: rgba(245, 245, 250, 0.85);
-  --modal-backstop: rgba(248, 248, 252, 0.92);
+  --modal-backstop-rgb: 248, 248, 252;
   --settings-modal-bg-rgb: 248, 248, 252;
   --settings-modal-bg-alpha: 0.84;
   --settings-modal-panel-rgb: 255, 255, 255;
@@ -6967,6 +6968,13 @@ body.density-compact #quick-controls .camera-preview-tile .camera-tile-preview-s
 }
 
 .modal-content {
+  /* Backstop under the glass tint: with the tint above it the panel lands at
+     roughly 75% opacity at full window opacity, and scales down with the
+     user's window-opacity setting, with a floor so dialogs stay readable.
+     Declared here (not :root) so var(--window-bg-alpha) resolves against the
+     value the app sets on body. */
+  --modal-backstop-alpha: max(0.3, calc(0.55 * var(--window-bg-alpha, 1)));
+  --modal-backstop: rgba(var(--modal-backstop-rgb), var(--modal-backstop-alpha));
   background: linear-gradient(var(--glass-elevated), var(--glass-elevated)), var(--modal-backstop);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-xl);

--- a/styles.css
+++ b/styles.css
@@ -97,6 +97,10 @@ html {
   --glass-surface: rgba(30, 30, 35, 0.7);
   --glass-elevated: rgba(40, 40, 45, 0.8);
   --glass-overlay: rgba(20, 20, 25, 0.85);
+  /* Near-opaque layer painted beneath modal glass tints so dialog text stays
+     readable even where backdrop-filter silently fails (e.g. transparent
+     Electron windows on Linux/Windows). */
+  --modal-backstop: rgba(26, 26, 31, 0.92);
   --settings-modal-bg-rgb: 24, 24, 29;
   --settings-modal-bg-alpha: 0.82;
   --settings-modal-panel-rgb: 31, 31, 37;
@@ -246,6 +250,7 @@ html {
   --glass-surface: rgba(255, 255, 255, 0.7);
   --glass-elevated: rgba(250, 250, 250, 0.8);
   --glass-overlay: rgba(245, 245, 250, 0.85);
+  --modal-backstop: rgba(248, 248, 252, 0.92);
   --settings-modal-bg-rgb: 248, 248, 252;
   --settings-modal-bg-alpha: 0.84;
   --settings-modal-panel-rgb: 255, 255, 255;
@@ -415,7 +420,7 @@ body.software-glass.frosted-glass .modal-content {
       rgba(255, 255, 255, var(--software-acrylic-highlight-alpha, 0.08)),
       rgba(255, 255, 255, 0)
     ),
-    var(--glass-elevated);
+    linear-gradient(var(--glass-elevated), var(--glass-elevated)), var(--modal-backstop);
   backdrop-filter: blur(var(--bg-blur)) saturate(170%) contrast(108%);
   -webkit-backdrop-filter: blur(var(--bg-blur)) saturate(170%) contrast(108%);
   box-shadow:
@@ -501,7 +506,7 @@ body.theme-light.frosted-glass .loading-overlay {
 
 /* Modal content in frosted glass mode */
 body.frosted-glass .modal-content {
-  background: var(--glass-elevated);
+  background: linear-gradient(var(--glass-elevated), var(--glass-elevated)), var(--modal-backstop);
   border: 1px solid rgba(255, 255, 255, 0.08);
 }
 
@@ -6962,7 +6967,7 @@ body.density-compact #quick-controls .camera-preview-tile .camera-tile-preview-s
 }
 
 .modal-content {
-  background: var(--glass-elevated);
+  background: linear-gradient(var(--glass-elevated), var(--glass-elevated)), var(--modal-backstop);
   border: 1px solid var(--border-color);
   border-radius: var(--radius-xl);
   max-width: 85vw;


### PR DESCRIPTION
## Summary

Fixes the see-through Persistent Notifications dialog (reported via screenshot: entity tiles behind the dialog bled through the panel, making the notification text unreadable).

**Root cause:** every dialog built on `.modal-content` uses the translucent `--glass-elevated` surface (~45% opaque in frosted-glass mode) and relies on `backdrop-filter` blur for legibility. On transparent Electron windows (Linux, and Windows without acrylic), `backdrop-filter` silently fails to render, so whatever is behind the dialog shows through raw and sharp.

**Fix:** paint a `--modal-backstop` layer beneath the glass tint in all `.modal-content` variants (base, frosted-glass, software-glass):

- With the glass tint above it, the panel lands at roughly **75% total opacity** at full window opacity — still visibly glassy, but text stays readable even with no blur at all.
- The backstop alpha **scales with the user's window-opacity setting** (via `--window-bg-alpha`), so a very translucent widget gets a proportionally lighter dialog.
- A **30% floor** keeps dialogs readable at the slider minimum (where surfaces otherwise drop to 8% alpha).
- The alpha is computed on `.modal-content` rather than `:root` because `var()` references inside custom properties resolve where the property is declared, and `--window-bg-alpha` is set on `body` at runtime.

The Settings modal is unaffected (it already has its own high-alpha background). Light theme gets a matching light backstop color.

## Testing

- Loaded the app's `index.html` in Chromium and verified the layered background resolves correctly in default, frosted-dark, frosted-light, and software-glass modes.
- Verified the computed backstop alpha scales with `--window-bg-alpha` (0.55 at full opacity → 0.30 floor at minimum) and that the light-theme color override applies.
- Before/after screenshots over a high-contrast background confirm readable text with `backdrop-filter` force-disabled, with the glass effect preserved where blur works.
- `prettier --check styles.css` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ScJfXHBTxv5zumzgimyTJ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01ScJfXHBTxv5zumzgimyTJ4)_