### PR TITLE
Smooth Home Assistant light brightness transitions

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -56,6 +56,8 @@ const desiredStateByEntity = new Map();
 const inFlightByEntity = new Map();
 const lastRequestedStateByEntity = new Map();
 const optimisticStateByEntity = new Map();
+const onOffToggleConfirmationTimers = new Map();
+const lastKnownLightBrightnessByEntity = new Map();
 const failedMediaArtworkRetryAtByUrl = new Map();
 const desktopPinLightBrightnessTimers = new Map();
 const desktopPinLightInteractionState = new Map();
@@ -63,6 +65,7 @@ const desktopPinControlTimers = new Map();
 const desktopPinControlInteractionState = new Map();
 const desktopPinSceneMinSyncState = new Map();
 const MEDIA_ARTWORK_RETRY_DELAY_MS = 30000;
+const ON_OFF_TOGGLE_CONFIRMATION_TIMEOUT_MS = 8000;
 const MEDIA_PLAYER_SUPPORT_VOLUME_SET = 4;
 const MEDIA_PLAYER_SUPPORT_VOLUME_MUTE = 8;
 const LIGHT_COLOR_MODES = new Set(['rgb', 'rgbw', 'rgbww', 'hs', 'xy']);
@@ -194,20 +197,79 @@ function getEffectiveOnOffState(entityId, fallbackState = 'off') {
   return isOnOffStateValue(fallbackState) ? fallbackState : 'off';
 }
 
+function clearOnOffToggleConfirmationTimer(entityId) {
+  const timer = onOffToggleConfirmationTimers.get(entityId);
+  if (timer != null) {
+    clearTimeout(timer);
+    onOffToggleConfirmationTimers.delete(entityId);
+  }
+}
+
 function clearPendingOnOffToggle(entityId) {
+  clearOnOffToggleConfirmationTimer(entityId);
   desiredStateByEntity.delete(entityId);
   optimisticStateByEntity.delete(entityId);
+  lastRequestedStateByEntity.delete(entityId);
+}
+
+function rememberLightBrightness(entity) {
+  if (getEntityDomain(entity?.entity_id) !== 'light') return;
+  const brightness = Number(entity?.attributes?.brightness);
+  if (Number.isFinite(brightness) && brightness > 0) {
+    lastKnownLightBrightnessByEntity.set(entity.entity_id, brightness);
+  }
 }
 
 function getEntityForDisplay(entity) {
   if (!entity || typeof entity !== 'object' || !entity.entity_id) return entity;
   const domain = getEntityDomain(entity.entity_id);
+  if (domain === 'light') rememberLightBrightness(entity);
   if (!isOnOffToggleDomain(domain)) return entity;
 
   const optimisticState = optimisticStateByEntity.get(entity.entity_id);
   if (!isOnOffStateValue(optimisticState)) return entity;
-  if (entity.state === optimisticState) return entity;
-  return { ...entity, state: optimisticState };
+
+  const cachedBrightness = lastKnownLightBrightnessByEntity.get(entity.entity_id);
+  const needsCachedBrightness =
+    domain === 'light' &&
+    optimisticState === 'on' &&
+    Number.isFinite(cachedBrightness) &&
+    !(Number(entity.attributes?.brightness) > 0);
+
+  if (entity.state === optimisticState && !needsCachedBrightness) return entity;
+  return {
+    ...entity,
+    state: optimisticState,
+    ...(needsCachedBrightness
+      ? { attributes: { ...(entity.attributes || {}), brightness: cachedBrightness } }
+      : {}),
+  };
+}
+
+function scheduleOnOffToggleConfirmationTimeout(entityId, domain, desiredState) {
+  clearOnOffToggleConfirmationTimer(entityId);
+  const timer = setTimeout(() => {
+    if (onOffToggleConfirmationTimers.get(entityId) !== timer) return;
+    onOffToggleConfirmationTimers.delete(entityId);
+    if (desiredStateByEntity.get(entityId) !== desiredState) return;
+
+    desiredStateByEntity.delete(entityId);
+    optimisticStateByEntity.delete(entityId);
+    lastRequestedStateByEntity.delete(entityId);
+
+    const serverEntity = state.STATES?.[entityId];
+    if (serverEntity) {
+      updateEntityInUI(serverEntity, { skipQueueReconcile: true });
+    }
+    emitUiDebug('entity.toggle_confirmation_timeout', {
+      entityId,
+      domain,
+      desiredState,
+      receivedState: serverEntity?.state || null,
+    });
+  }, ON_OFF_TOGGLE_CONFIRMATION_TIMEOUT_MS);
+  timer?.unref?.();
+  onOffToggleConfirmationTimers.set(entityId, timer);
 }
 
 /**
@@ -1684,7 +1746,7 @@ function updateEntityInUI(entity, options = {}) {
           });
         } else {
           optimisticStateByEntity.set(entityId, desiredState);
-          renderEntity = { ...entity, state: desiredState };
+          renderEntity = getEntityForDisplay(entity);
           emitUiDebug('entity.toggle_reconcile_pending', {
             entityId,
             domain,
@@ -1816,6 +1878,7 @@ function applyQuickAccessTileActiveState(element, entity) {
 }
 
 function getControlRenderSignature(entity) {
+  entity = getEntityForDisplay(entity);
   if (!entity || !entity.entity_id) return '';
   const attrs = entity.attributes || {};
   const domain = getEntityDomain(entity.entity_id);
@@ -9318,16 +9381,13 @@ async function processPendingOnOffToggle(entityId, domain) {
     const latestDesiredState = desiredStateByEntity.get(entityId);
     if (latestDesiredState === desiredState) {
       const currentEntity = state.STATES?.[entityId];
-      if (currentEntity) {
-        const committedEntity =
-          currentEntity.state === desiredState
-            ? currentEntity
-            : { ...currentEntity, state: desiredState };
-        state.setEntityState(committedEntity);
+      if (!currentEntity) {
         clearPendingOnOffToggle(entityId);
-        updateEntityInUI(committedEntity, { skipQueueReconcile: true });
       } else {
-        clearPendingOnOffToggle(entityId);
+        // A successful service response only confirms that Home Assistant accepted the call.
+        // Keep the requested visual state until the matching state_changed event arrives so an
+        // older entity update cannot briefly repaint the tile with stale data.
+        scheduleOnOffToggleConfirmationTimeout(entityId, domain, desiredState);
       }
     }
 
@@ -9385,6 +9445,8 @@ function queueOnOffToggle(entity) {
 
   const effectiveState = getEffectiveOnOffState(entityId, entity.state);
   const desiredState = effectiveState === 'on' ? 'off' : 'on';
+  clearOnOffToggleConfirmationTimer(entityId);
+  rememberLightBrightness(state.STATES?.[entityId] || entity);
   desiredStateByEntity.set(entityId, desiredState);
   optimisticStateByEntity.set(entityId, desiredState);
 

--- a/tests/unit/ui.test.js
+++ b/tests/unit/ui.test.js
@@ -230,6 +230,7 @@ describe('UI Rendering - Selective Business Logic Tests (ui.js)', () => {
     });
 
     afterEach(() => {
+      jest.runOnlyPendingTimers();
       jest.useRealTimers();
     });
 
@@ -599,6 +600,94 @@ describe('UI Rendering - Selective Business Logic Tests (ui.js)', () => {
 
       resolveFirstCall({});
       await flushAsync();
+    });
+
+    it('should keep the optimistic level after service acknowledgement until HA confirms the state', async () => {
+      state.setConfig({
+        ...sampleConfig,
+        ui: { ...sampleConfig.ui },
+        favoriteEntities: ['light.bedroom'],
+      });
+      state.setStates({
+        'light.bedroom': getBedroomLightOnState(),
+      });
+      ui.renderActiveTab();
+
+      ui.executeHotkeyAction(state.STATES['light.bedroom'], 'toggle');
+      await flushAsync();
+
+      // The service response has settled, but an older state update must not restore 78%.
+      ui.updateEntityInUI(getBedroomLightOnState());
+      expect(
+        document.querySelector('.control-item[data-entity-id="light.bedroom"] .control-state')
+          .textContent
+      ).toBe('Off');
+
+      ui.updateEntityInUI(getBedroomLightOffState());
+      expect(
+        document.querySelector('.control-item[data-entity-id="light.bedroom"] .control-state')
+          .textContent
+      ).toBe('Off');
+    });
+
+    it('should ignore an out-of-order off update after a rapid toggle back on', async () => {
+      state.setConfig({
+        ...sampleConfig,
+        ui: { ...sampleConfig.ui },
+        favoriteEntities: ['light.bedroom'],
+      });
+      state.setStates({
+        'light.bedroom': getBedroomLightOnState(),
+      });
+      ui.renderActiveTab();
+
+      ui.executeHotkeyAction(state.STATES['light.bedroom'], 'toggle');
+      ui.executeHotkeyAction(state.STATES['light.bedroom'], 'toggle');
+      await flushAsync();
+      await flushAsync();
+
+      ui.updateEntityInUI(getBedroomLightOffState());
+      expect(
+        document.querySelector('.control-item[data-entity-id="light.bedroom"] .control-state')
+          .textContent
+      ).toBe('78%');
+
+      ui.updateEntityInUI(getBedroomLightOnState());
+      expect(
+        document.querySelector('.control-item[data-entity-id="light.bedroom"] .control-state')
+          .textContent
+      ).toBe('78%');
+    });
+
+    it('should reuse the last confirmed brightness while an off light is turning on', () => {
+      const entityId = 'light.cached_brightness';
+      const onState = {
+        entity_id: entityId,
+        state: 'on',
+        attributes: { friendly_name: 'Cached Brightness', brightness: 128 },
+      };
+      const offState = {
+        entity_id: entityId,
+        state: 'off',
+        attributes: { friendly_name: 'Cached Brightness' },
+      };
+      state.setConfig({
+        ...sampleConfig,
+        ui: { ...sampleConfig.ui },
+        favoriteEntities: [entityId],
+      });
+      state.setStates({ [entityId]: onState });
+      ui.renderActiveTab();
+
+      state.setEntityState(offState);
+      ui.updateEntityInUI(offState);
+      mockCallService.mockImplementationOnce(() => new Promise(() => {}));
+      ui.executeHotkeyAction(state.STATES[entityId], 'toggle');
+
+      expect(
+        document.querySelector(`.control-item[data-entity-id="${entityId}"] .control-state`)
+          .textContent
+      ).toBe('50%');
     });
 
     it('should revert optimistic state when service call fails', async () => {


### PR DESCRIPTION
## Summary

- keep optimistic light state visible until Home Assistant confirms the matching entity state
- ignore stale and out-of-order state updates during light toggles
- reuse the last confirmed brightness while an off light is turning back on
- reconcile to the server state after an eight-second confirmation timeout

## Root cause

A successful `call_service` response was treated as authoritative state confirmation. Home Assistant acknowledges that request before the corresponding `state_changed` event, allowing an older entity update to repaint the tile in between. Lights turning on could also lack a brightness attribute until the confirmed state arrived, leaving the level temporarily blank.

## User impact

Light tiles no longer flash from `Off` back to the old percentage or lose their brightness label during normal on/off transitions. Rapid toggles remain visually stable when entity updates arrive out of order.

## Validation

Validated from a clean worktree at commit `f8fc568`:

- `npm test -- --runInBand --detectOpenHandles` — 67 suites, 1,284 tests passed
- `npm run build:renderer`
- `npx eslint src/ui.js tests/unit/ui.test.js`
- `npx prettier --check src/ui.js tests/unit/ui.test.js`