### PR TITLE
test: make matchMedia mock configurable

### DIFF
--- a/tests/unit/ui-utils.test.js
+++ b/tests/unit/ui-utils.test.js
@@ -12,6 +12,7 @@ window.electronAPI = mockElectronAPI;
 // Mock matchMedia for theme detection
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
+  configurable: true,
   value: jest.fn().mockImplementation((query) => ({
     matches: false,
     media: query,


### PR DESCRIPTION
## Summary

Cherry-picks the one-line test fix from #80 (author: @abla86, authorship preserved) so it lands without the unrelated native-rebuild and CI changes that were attached there. #80 has been closed.

Adds `configurable: true` to the top-level `window.matchMedia` mock in `tests/unit/ui-utils.test.js`, so later tests in the file can redefine it.

## Verification

- `npx jest tests/unit/ui-utils.test.js`: 101/101 passed
- `npx eslint tests/unit/ui-utils.test.js`: clean

Test-only change; no runtime behavior affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PSgadoNyhSxyXL976dTUaG

---
_Generated by [Claude Code](https://claude.ai/code/session_01PSgadoNyhSxyXL976dTUaG)_